### PR TITLE
Icd10pcs no deprecation no classification

### DIFF
--- a/ICD10PCS/load_stage.sql
+++ b/ICD10PCS/load_stage.sql
@@ -35,7 +35,7 @@ TRUNCATE TABLE concept_synonym_stage;
 TRUNCATE TABLE pack_content_stage;
 TRUNCATE TABLE drug_strength_stage;
 
---3. Insert into concept_stage
+--3. Add all billable ICD10PCS Procedures (77559) and 3-character Hierarchical terms (880) (number of concepts has to be equal to https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10PCS/stats.html)
 INSERT INTO concept_stage (
 	concept_name,
 	vocabulary_id,
@@ -50,8 +50,11 @@ INSERT INTO concept_stage (
 SELECT concept_name,
 	'ICD10PCS' AS vocabulary_id,
 	'Procedure' AS domain_id,
-	'ICD10PCS' AS concept_class_id,
-	'S' AS standard_concept,
+	case length (concept_code) 
+		when 7 then 'ICD10PCS' -- billable codes have length(concept_code) = 7
+		else 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
+	end AS concept_class_id,
+	 'S' AS standard_concept, -- non-billable Hierarchy concepts are met in patient data, that is why they are considered to be Standard as well
 	concept_code,
 	(
 		SELECT latest_update
@@ -60,9 +63,9 @@ SELECT concept_name,
 		) AS valid_start_date,
 	TO_DATE('20991231', 'yyyymmdd') AS valid_end_date,
 	NULL AS invalid_reason
-FROM SOURCES.icd10pcs;
+FROM SOURCES.icd10pcs; -- 78 439
 
---4. Add 'ICD10PCS Hierarchy' from umls.mrconso
+--4. Add all the other ICD10PCS Hierarchical terms from umls.mrconso -- why are they coming from different sources?
 INSERT INTO concept_stage (
 	concept_name,
 	vocabulary_id,
@@ -78,22 +81,15 @@ SELECT DISTINCT
 	-- take the best str
 	FIRST_VALUE(SUBSTR(str, 1, 255)) OVER (
 		PARTITION BY code ORDER BY CASE tty
-				WHEN 'HT'
+				WHEN 'HT' -- Hierarchical term
 					THEN 1
-				WHEN 'MTH_HX'
+				WHEN 'HS' -- Short or alternate version of hierarchical term
 					THEN 2
-				WHEN 'HX'
+				WHEN 'HX' -- 	Expanded version of short hierarchical term 
 					THEN 3
-				WHEN 'HS'
+				WHEN 'MTH_HX' -- MTH Hierarchical term expanded 
 					THEN 4
-				WHEN 'PT'
-					THEN 5
-				WHEN 'PX'
-					THEN 6
-				WHEN 'AB'
-					THEN 7
-				WHEN 'XM'
-					THEN 8
+				ELSE 5
 				END,
 			CASE 
 				WHEN LENGTH(str) <= 255
@@ -106,7 +102,7 @@ SELECT DISTINCT
 	'ICD10PCS' AS vocabulary_id,
 	'Procedure' AS domain_id,
 	'ICD10PCS Hierarchy' AS concept_class_id,
-	'S' AS standard_concept,
+	'S' AS standard_concept, -- non-billable Hierarchy concepts are met in patient data, that is why they are considered to be Standard as well
 	code AS concept_code,
 	TO_DATE('19700101', 'yyyymmdd') AS valid_start_date,
 	TO_DATE('20991231', 'yyyymmdd') AS valid_end_date,
@@ -117,9 +113,9 @@ WHERE sab = 'ICD10PCS'
 		SELECT 1
 		FROM concept_stage cs
 		WHERE cs.concept_code = code
-		);
+		); -- 111060
 
---5. Add all synonyms to concept_synonym stage from umls.mrconso
+--5. Add all synonyms from umls.mrconso to concept_synonym stage
 INSERT INTO concept_synonym_stage (
 	synonym_concept_code,
 	synonym_name,
@@ -133,10 +129,96 @@ SELECT code AS concept_code,
 FROM SOURCES.mrconso
 WHERE sab = 'ICD10PCS'
 GROUP BY code,
-	str;
+	str; -- 324257
 
---6. Add "subsumes" relationship between concepts where the concept_code is like of another
-CREATE INDEX IF NOT EXISTS trgm_idx ON concept_stage USING GIN (concept_code devv5.gin_trgm_ops); --for LIKE patterns
+--6. "Resurrect" previously deprecated concepts using the basic tables (they, being encountered in patient data, must remain Standard!). 
+-- Add 'Deprecated' to concept_name to show the fact of deprecation by the source (we expect codes to be deprecated each release cycle)
+INSERT INTO concept_stage (
+	concept_name,
+	vocabulary_id,
+	domain_id,
+	concept_class_id,
+	standard_concept,
+	concept_code,
+	valid_start_date,
+	valid_end_date,
+	invalid_reason
+	)
+select
+	case
+		when c.concept_name like '% (Deprecated)' then c.concept_name -- to support subsequent source deprecations 
+		when length (c.concept_name) <= 242 then c.concept_name || ' (Deprecated)' -- to get no more than 255 characters in total
+		else left (c.concept_name, 239) || '... (Deprecated)' -- to get no more than 255 characters in total and highlight concept_names which were cut
+	end as concept_name,
+	'ICD10PCS',
+	'Procedure',
+	case length (c.concept_code)
+		when 7 then 'ICD10PCS' -- billable codes have length(concept_code) = 7
+		else 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
+	end as concept_class_id,
+  'S' AS standard_concept, -- resurrection as is
+	c.concept_code,
+	c.valid_start_date,
+	(SELECT latest_update-1 FROM vocabulary WHERE vocabulary_id = c.vocabulary_id) AS valid_end_date, -- analogically to https://github.com/OHDSI/Vocabulary-v5.0/blob/4752f272a51761df2bda3b5c692b657c72f52027/working/generic_update.sql#L240
+	null as invalid_reason	
+from concept c
+left join concept_stage s on
+	c.concept_code = s.concept_code
+where
+	c.vocabulary_id = 'ICD10PCS' and
+	s.concept_code is null and
+	c.concept_code not like 'MTHU00000_' -- to exclude internal technical source codes
+; -- 4271
+
+--7. Add synonyms for resurrected concepts using the concept_synonym table
+INSERT INTO concept_synonym_stage (
+	synonym_concept_code,
+	synonym_name,
+	synonym_vocabulary_id,
+	language_concept_id
+	)
+select
+	c.concept_code,
+	s.concept_synonym_name,
+	'ICD10PCS' AS vocabulary_id,
+	4180186 AS language_concept_id
+from concept_synonym s
+join concept c on
+	c.concept_id = s.concept_id and
+	c.vocabulary_id = 'ICD10PCS'
+left join sources.icd10pcs i on
+	i.concept_code = c.concept_code
+where
+	i.concept_code is null and
+	c.concept_code not like 'MTHU00000_'  -- to exclude internal technical source codes
+;-- 120860
+
+--8. Add original names of resurrected concepts using the concept table
+INSERT INTO concept_synonym_stage (
+	synonym_concept_code,
+	synonym_name,
+	synonym_vocabulary_id,
+	language_concept_id
+	)
+select
+	c.concept_code,
+	c.concept_name,
+	'ICD10PCS' AS vocabulary_id,
+	4180186 AS language_concept_id
+from concept c
+left join sources.icd10pcs i on
+	i.concept_code = c.concept_code
+left join concept_synonym_stage a on
+	(c.concept_code,c.concept_name) = (a.synonym_concept_code,a.synonym_name)
+where
+	c.vocabulary_id = 'ICD10PCS' and
+	i.concept_code is null and
+	a.synonym_concept_code is null and
+	c.concept_code not like 'MTHU00000_'  -- to exclude internal technical source codes
+; -- 12 
+
+--9. Build 'Subsumes' relationships from ancestors to immediate descendants using concept code similarity (c2.concept_code LIKE c1.concept_code || '_')
+CREATE INDEX IF NOT EXISTS trgm_idx ON concept_stage USING GIN (concept_code devv5.gin_trgm_ops); -- for LIKE patterns
 INSERT INTO concept_relationship_stage (
 	concept_code_1,
 	concept_code_2,
@@ -169,37 +251,76 @@ WHERE c2.concept_code LIKE c1.concept_code || '_'
 		WHERE r_int.concept_code_1 = c1.concept_code
 			AND r_int.concept_code_2 = c2.concept_code
 			AND r_int.relationship_id = 'Subsumes'
-		);
+		); -- 193753
+
+--10. Deprecate 'Subsumes' relationships for resurrected concepts to avoid possible violations of the hierarchy
+INSERT INTO concept_relationship_stage (
+	concept_code_1,
+	concept_code_2,
+	vocabulary_id_1,
+	vocabulary_id_2,
+	relationship_id,
+	valid_start_date,
+	valid_end_date,
+	invalid_reason
+	)
+select
+	c.concept_code AS concept_code_1,
+	c2.concept_code AS concept_code_2,
+	c.vocabulary_id AS vocabulary_id_1,
+	c2.vocabulary_id AS vocabulary_id_2,
+	'Subsumes' AS relationship_id,
+	r.valid_start_date AS valid_start_date,
+	(
+		SELECT latest_update - 1
+		FROM vocabulary
+		WHERE vocabulary_id = c.vocabulary_id
+	) AS valid_end_date,
+	'D' AS invalid_reason
+from concept c
+join concept_relationship r on
+	c.vocabulary_id = 'ICD10PCS' and
+	r.concept_id_1 = c.concept_id and
+	r.relationship_id = 'Subsumes'
+join concept c2 on
+	c2.vocabulary_id = 'ICD10PCS' and
+	r.concept_id_2 = c2.concept_id
+left join concept_relationship_stage s on
+	c.concept_code = s.concept_code_1 and
+	c2.concept_code = s.concept_code_2 and
+	s.relationship_id = 'Subsumes'
+where s.concept_code_1 is null
+; -- 19395
 DROP INDEX trgm_idx;
 
---7. Add ICD10CM to RxNorm manual mappings
+--11. Add ICD10PCS to SNOMED relations
 DO $_$
 BEGIN
 	PERFORM VOCABULARY_PACK.ProcessManualRelationships();
 END $_$;
 
---8. Working with replacement mappings
+--12. Working with replacement mappings
 DO $_$
 BEGIN
 	PERFORM VOCABULARY_PACK.CheckReplacementMappings();
 END $_$;
 
---9. Add mapping from deprecated to fresh concepts
+--13. Add mapping from deprecated to fresh concepts
 DO $_$
 BEGIN
 	PERFORM VOCABULARY_PACK.AddFreshMAPSTO();
 END $_$;
 
---10. Deprecate 'Maps to' mappings to deprecated and upgraded concepts
+--14. Deprecate 'Maps to' mappings to deprecated and upgraded concepts
 DO $_$
 BEGIN
 	PERFORM VOCABULARY_PACK.DeprecateWrongMAPSTO();
 END $_$;
 
---11. Delete ambiguous 'Maps to' mappings
+--15. Delete ambiguous 'Maps to' mappings
 DO $_$
 BEGIN
 	PERFORM VOCABULARY_PACK.DeleteAmbiguousMAPSTO();
 END $_$;
 
--- At the end, the three tables concept_stage, concept_relationship_stage and concept_synonym_stage should be ready to be fed into the generic_update.sql script
+-- At the end, the concept_stage, concept_relationship_stage and concept_synonym_stage tables are ready to be fed into the generic_update script

--- a/ICD10PCS/load_stage.sql
+++ b/ICD10PCS/load_stage.sql
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 * 
-* Authors: Timur Vakhitov, Christian Reich
-* Date: 2017
+* Authors: Timur Vakhitov, Christian Reich, Eduard Korchmar
+* Date: 2020
 **************************************************************************/
 
 --1. Update latest_update field to new date
@@ -35,7 +35,7 @@ TRUNCATE TABLE concept_synonym_stage;
 TRUNCATE TABLE pack_content_stage;
 TRUNCATE TABLE drug_strength_stage;
 
---3. Add all billable ICD10PCS Procedures (77559) and 3-character Hierarchical terms (880) (number of concepts has to be equal to https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10PCS/stats.html)
+--3. Add all billable ICD10PCS Procedures and 3-character Hierarchical terms (number of inserted concepts has to be equal to https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10PCS/stats.html)
 INSERT INTO concept_stage (
 	concept_name,
 	vocabulary_id,
@@ -48,24 +48,22 @@ INSERT INTO concept_stage (
 	invalid_reason
 	)
 SELECT concept_name,
-	'ICD10PCS' AS vocabulary_id,
-	'Procedure' AS domain_id,
-	case length (concept_code) 
-		when 7 then 'ICD10PCS' -- billable codes have length(concept_code) = 7
-		else 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
-	end AS concept_class_id,
-	 'S' AS standard_concept, -- non-billable Hierarchy concepts are met in patient data, that is why they are considered to be Standard as well
-	concept_code,
-	(
-		SELECT latest_update
-		FROM vocabulary
-		WHERE vocabulary_id = 'ICD10PCS'
-		) AS valid_start_date,
-	TO_DATE('20991231', 'yyyymmdd') AS valid_end_date,
-	NULL AS invalid_reason
-FROM SOURCES.icd10pcs; -- 78 439
+       'ICD10PCS' AS vocabulary_id,
+       'Procedure' AS domain_id,
+       CASE LENGTH(concept_code)
+         WHEN 7 THEN 'ICD10PCS' -- billable codes have length(concept_code) = 7
+         ELSE 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
+       END AS concept_class_id,
+       'S' AS standard_concept, -- non-billable Hierarchy concepts are met in patient data, that is why they are considered to be Standard as well
+       concept_code,
+       (SELECT latest_update
+        FROM vocabulary
+        WHERE vocabulary_id = 'ICD10PCS') AS valid_start_date,
+       TO_DATE('20991231','yyyymmdd') AS valid_end_date,
+       NULL AS invalid_reason
+FROM sources.icd10pcs;
 
---4. Add all the other ICD10PCS Hierarchical terms from umls.mrconso -- why are they coming from different sources?
+--4. Add all the other ICD10PCS Hierarchical terms from umls.mrconso
 INSERT INTO concept_stage (
 	concept_name,
 	vocabulary_id,
@@ -107,13 +105,13 @@ SELECT DISTINCT
 	TO_DATE('19700101', 'yyyymmdd') AS valid_start_date,
 	TO_DATE('20991231', 'yyyymmdd') AS valid_end_date,
 	NULL AS invalid_reason
-FROM SOURCES.mrconso
+FROM sources.mrconso
 WHERE sab = 'ICD10PCS'
 	AND NOT EXISTS (
 		SELECT 1
 		FROM concept_stage cs
 		WHERE cs.concept_code = code
-		); -- 111060
+		);
 
 --5. Add all synonyms from umls.mrconso to concept_synonym stage
 INSERT INTO concept_synonym_stage (
@@ -129,10 +127,10 @@ SELECT code AS concept_code,
 FROM SOURCES.mrconso
 WHERE sab = 'ICD10PCS'
 GROUP BY code,
-	str; -- 324257
+	str;
 
---6. "Resurrect" previously deprecated concepts using the basic tables (they, being encountered in patient data, must remain Standard!). 
--- Add 'Deprecated' to concept_name to show the fact of deprecation by the source (we expect codes to be deprecated each release cycle)
+--6. "Resurrect" previously deprecated concepts using the basic tables (they, being encountered in patient data, must remain Standard!)
+-- Add 'Deprecated' to concept_names to show the fact of deprecation by the source (we expect codes to be deprecated each release cycle)
 INSERT INTO concept_stage (
 	concept_name,
 	vocabulary_id,
@@ -144,31 +142,30 @@ INSERT INTO concept_stage (
 	valid_end_date,
 	invalid_reason
 	)
-select
-	case
-		when c.concept_name like '% (Deprecated)' then c.concept_name -- to support subsequent source deprecations 
-		when length (c.concept_name) <= 242 then c.concept_name || ' (Deprecated)' -- to get no more than 255 characters in total
-		else left (c.concept_name, 239) || '... (Deprecated)' -- to get no more than 255 characters in total and highlight concept_names which were cut
-	end as concept_name,
-	'ICD10PCS',
-	'Procedure',
-	case length (c.concept_code)
-		when 7 then 'ICD10PCS' -- billable codes have length(concept_code) = 7
-		else 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
-	end as concept_class_id,
-  'S' AS standard_concept, -- resurrection as is
-	c.concept_code,
-	c.valid_start_date,
-	(SELECT latest_update-1 FROM vocabulary WHERE vocabulary_id = c.vocabulary_id) AS valid_end_date, -- analogically to https://github.com/OHDSI/Vocabulary-v5.0/blob/4752f272a51761df2bda3b5c692b657c72f52027/working/generic_update.sql#L240
-	null as invalid_reason	
-from concept c
-left join concept_stage s on
-	c.concept_code = s.concept_code
-where
-	c.vocabulary_id = 'ICD10PCS' and
-	s.concept_code is null and
-	c.concept_code not like 'MTHU00000_' -- to exclude internal technical source codes
-; -- 4271
+SELECT CASE
+         WHEN c.concept_name LIKE '% (Deprecated)' THEN c.concept_name -- to support subsequent source deprecations 
+         WHEN LENGTH(c.concept_name) <= 242 THEN c.concept_name || ' (Deprecated)' -- to get no more than 255 characters in total
+         ELSE LEFT (c.concept_name,239) || '... (Deprecated)' -- to get no more than 255 characters in total and highlight concept_names which were cut
+       END AS concept_name,
+       'ICD10PCS',
+       'Procedure',
+       CASE LENGTH(c.concept_code)
+         WHEN 7 THEN 'ICD10PCS' -- billable codes have length(concept_code) = 7
+         ELSE 'ICD10PCS Hierarchy' -- non-billable codes have length(concept_code) < 7
+       END AS concept_class_id,
+       'S' AS standard_concept, -- resurrection as is
+       c.concept_code,
+       c.valid_start_date,
+       (SELECT latest_update -1
+        FROM vocabulary
+        WHERE vocabulary_id = c.vocabulary_id) AS valid_end_date, -- analogically to https://github.com/OHDSI/Vocabulary-v5.0/blob/4752f272a51761df2bda3b5c692b657c72f52027/working/generic_update.sql#L240
+       NULL AS invalid_reason
+FROM concept c
+  LEFT JOIN concept_stage s ON c.concept_code = s.concept_code
+WHERE c.vocabulary_id = 'ICD10PCS'
+AND   s.concept_code IS NULL
+AND   c.concept_code NOT LIKE 'MTHU00000_' -- to exclude internal technical source codes
+;
 
 --7. Add synonyms for resurrected concepts using the concept_synonym table
 INSERT INTO concept_synonym_stage (
@@ -177,45 +174,39 @@ INSERT INTO concept_synonym_stage (
 	synonym_vocabulary_id,
 	language_concept_id
 	)
-select
-	c.concept_code,
-	s.concept_synonym_name,
-	'ICD10PCS' AS vocabulary_id,
-	4180186 AS language_concept_id
-from concept_synonym s
-join concept c on
-	c.concept_id = s.concept_id and
-	c.vocabulary_id = 'ICD10PCS'
-left join sources.icd10pcs i on
-	i.concept_code = c.concept_code
-where
-	i.concept_code is null and
-	c.concept_code not like 'MTHU00000_'  -- to exclude internal technical source codes
-;-- 120860
+SELECT c.concept_code,
+       s.concept_synonym_name,
+       'ICD10PCS' AS vocabulary_id,
+       4180186 AS language_concept_id
+FROM concept_synonym s
+  JOIN concept c
+    ON c.concept_id = s.concept_id
+   AND c.vocabulary_id = 'ICD10PCS'
+  LEFT JOIN sources.icd10pcs i ON i.concept_code = c.concept_code
+WHERE i.concept_code IS NULL
+AND   c.concept_code NOT LIKE 'MTHU00000_'  -- to exclude internal technical source codes
+;
 
 --8. Add original names of resurrected concepts using the concept table
-INSERT INTO concept_synonym_stage (
-	synonym_concept_code,
-	synonym_name,
-	synonym_vocabulary_id,
-	language_concept_id
-	)
-select
-	c.concept_code,
-	c.concept_name,
-	'ICD10PCS' AS vocabulary_id,
-	4180186 AS language_concept_id
-from concept c
-left join sources.icd10pcs i on
-	i.concept_code = c.concept_code
-left join concept_synonym_stage a on
-	(c.concept_code,c.concept_name) = (a.synonym_concept_code,a.synonym_name)
-where
-	c.vocabulary_id = 'ICD10PCS' and
-	i.concept_code is null and
-	a.synonym_concept_code is null and
-	c.concept_code not like 'MTHU00000_'  -- to exclude internal technical source codes
-; -- 12 
+INSERT INTO concept_synonym_stage
+(
+  synonym_concept_code,
+  synonym_name,
+  synonym_vocabulary_id,
+  language_concept_id
+)
+SELECT c.concept_code,
+       c.concept_name,
+       'ICD10PCS' AS vocabulary_id,
+       4180186 AS language_concept_id
+FROM concept c
+  LEFT JOIN sources.icd10pcs i ON i.concept_code = c.concept_code
+  LEFT JOIN concept_synonym_stage a ON (c.concept_code,c.concept_name) = (a.synonym_concept_code,a.synonym_name)
+WHERE c.vocabulary_id = 'ICD10PCS'
+AND   i.concept_code IS NULL
+AND   a.synonym_concept_code IS NULL
+AND   c.concept_code NOT LIKE 'MTHU00000_' -- to exclude internal technical source codes
+;
 
 --9. Build 'Subsumes' relationships from ancestors to immediate descendants using concept code similarity (c2.concept_code LIKE c1.concept_code || '_')
 CREATE INDEX IF NOT EXISTS trgm_idx ON concept_stage USING GIN (concept_code devv5.gin_trgm_ops); -- for LIKE patterns
@@ -251,7 +242,7 @@ WHERE c2.concept_code LIKE c1.concept_code || '_'
 		WHERE r_int.concept_code_1 = c1.concept_code
 			AND r_int.concept_code_2 = c2.concept_code
 			AND r_int.relationship_id = 'Subsumes'
-		); -- 193753
+		);
 
 --10. Deprecate 'Subsumes' relationships for resurrected concepts to avoid possible violations of the hierarchy
 INSERT INTO concept_relationship_stage (
@@ -264,33 +255,30 @@ INSERT INTO concept_relationship_stage (
 	valid_end_date,
 	invalid_reason
 	)
-select
-	c.concept_code AS concept_code_1,
-	c2.concept_code AS concept_code_2,
-	c.vocabulary_id AS vocabulary_id_1,
-	c2.vocabulary_id AS vocabulary_id_2,
-	'Subsumes' AS relationship_id,
-	r.valid_start_date AS valid_start_date,
-	(
-		SELECT latest_update - 1
-		FROM vocabulary
-		WHERE vocabulary_id = c.vocabulary_id
-	) AS valid_end_date,
-	'D' AS invalid_reason
-from concept c
-join concept_relationship r on
-	c.vocabulary_id = 'ICD10PCS' and
-	r.concept_id_1 = c.concept_id and
-	r.relationship_id = 'Subsumes'
-join concept c2 on
-	c2.vocabulary_id = 'ICD10PCS' and
-	r.concept_id_2 = c2.concept_id
-left join concept_relationship_stage s on
-	c.concept_code = s.concept_code_1 and
-	c2.concept_code = s.concept_code_2 and
-	s.relationship_id = 'Subsumes'
-where s.concept_code_1 is null
-; -- 19395
+SELECT c.concept_code AS concept_code_1,
+       c2.concept_code AS concept_code_2,
+       c.vocabulary_id AS vocabulary_id_1,
+       c2.vocabulary_id AS vocabulary_id_2,
+       'Subsumes' AS relationship_id,
+       r.valid_start_date AS valid_start_date,
+       (SELECT latest_update - 1
+        FROM vocabulary
+        WHERE vocabulary_id = c.vocabulary_id) AS valid_end_date,
+       'D' AS invalid_reason
+FROM concept c
+  JOIN concept_relationship r
+    ON c.vocabulary_id = 'ICD10PCS'
+   AND r.concept_id_1 = c.concept_id
+   AND r.relationship_id = 'Subsumes'
+  JOIN concept c2
+    ON c2.vocabulary_id = 'ICD10PCS'
+   AND r.concept_id_2 = c2.concept_id
+  LEFT JOIN concept_relationship_stage s
+         ON c.concept_code = s.concept_code_1
+        AND c2.concept_code = s.concept_code_2
+        AND s.relationship_id = 'Subsumes'
+WHERE s.concept_code_1 IS NULL
+;
 DROP INDEX trgm_idx;
 
 --11. Add ICD10PCS to SNOMED relations

--- a/working/QA_stage_tables.sql
+++ b/working/QA_stage_tables.sql
@@ -9,15 +9,14 @@ select distinct cs.vocabulary_id from concept_stage cs
 left join vocabulary v on v.vocabulary_id=cs.vocabulary_id and v.latest_update is not null
 where v.latest_update is null;
 
+
 select * From concept_relationship_stage where valid_start_date is null or valid_end_date is null or (invalid_reason is null and valid_end_date<>to_date ('20991231', 'yyyymmdd'))
 or (invalid_reason is not null and valid_end_date=to_date ('20991231', 'yyyymmdd'));
 
-select * from concept_stage where
-vocabulary_id not in ('CPT4', 'HCPCS', 'ICD9Proc', 'ICD10PCS') -- vocabularies having deprecated but Standard concepts with latest_update -1 AS valid_end_date
-and (valid_start_date is null or valid_end_date is null
+select * from concept_stage where valid_start_date is null or valid_end_date is null
 or (invalid_reason is null and valid_end_date <> to_date ('20991231', 'yyyymmdd') and vocabulary_id not in ('CPT4', 'HCPCS', 'ICD9Proc'))
 or (invalid_reason is not null and valid_end_date = to_date ('20991231', 'yyyymmdd'))
-or valid_start_date < to_date ('19000101', 'yyyymmdd'));  -- some concepts have a real date < 1970
+or valid_start_date < to_date ('19000101', 'yyyymmdd'); -- some concepts have a real date < 1970
 
 
 select relationship_id from concept_relationship_stage
@@ -48,6 +47,7 @@ group by concept_code_1, concept_code_2, vocabulary_id_1, vocabulary_id_2, relat
 
 select concept_code, vocabulary_id  from concept_stage
 group by concept_code, vocabulary_id  having count(*)>1;
+
 
 
 select pack_concept_code, pack_vocabulary_id, drug_concept_code, drug_vocabulary_id, amount from pack_content_stage

--- a/working/QA_stage_tables.sql
+++ b/working/QA_stage_tables.sql
@@ -9,14 +9,15 @@ select distinct cs.vocabulary_id from concept_stage cs
 left join vocabulary v on v.vocabulary_id=cs.vocabulary_id and v.latest_update is not null
 where v.latest_update is null;
 
-
 select * From concept_relationship_stage where valid_start_date is null or valid_end_date is null or (invalid_reason is null and valid_end_date<>to_date ('20991231', 'yyyymmdd'))
 or (invalid_reason is not null and valid_end_date=to_date ('20991231', 'yyyymmdd'));
 
-select * from concept_stage where valid_start_date is null or valid_end_date is null
+select * from concept_stage where
+vocabulary_id not in ('CPT4', 'HCPCS', 'ICD9Proc', 'ICD10PCS') -- vocabularies having deprecated but Standard concepts with latest_update -1 AS valid_end_date
+and (valid_start_date is null or valid_end_date is null
 or (invalid_reason is null and valid_end_date <> to_date ('20991231', 'yyyymmdd') and vocabulary_id not in ('CPT4', 'HCPCS', 'ICD9Proc'))
 or (invalid_reason is not null and valid_end_date = to_date ('20991231', 'yyyymmdd'))
-or valid_start_date < to_date ('19000101', 'yyyymmdd'); -- some concepts have a real date < 1970
+or valid_start_date < to_date ('19000101', 'yyyymmdd'));  -- some concepts have a real date < 1970
 
 
 select relationship_id from concept_relationship_stage
@@ -47,7 +48,6 @@ group by concept_code_1, concept_code_2, vocabulary_id_1, vocabulary_id_2, relat
 
 select concept_code, vocabulary_id  from concept_stage
 group by concept_code, vocabulary_id  having count(*)>1;
-
 
 
 select pack_concept_code, pack_vocabulary_id, drug_concept_code, drug_vocabulary_id, amount from pack_content_stage


### PR DESCRIPTION
1) Hierarchies get the correct concept class (Eddy's work)
2) Some concept names are better formulated (Eddy's work)
3) Hierarchies are kept Standard
4) Previously deprecated concepts become Standard  and are marked as 'Deprecated' in the concept names  (Eddy's work)
5) valid_end_dates for "resurrected" concepts are changed as in the vocabularies with a similar issue (CPT4, HCPCS, ICD9Proc). But the generic update returns an error. Need to change QA_TESTS.Check_Stage_Tables();
6) concept_relationship_manual was cleaned up a bit from erroneous hierarchical links. The manual concept ancestor was built successfully.
7) comments have been slightly rewritten.