### PR TITLE
Build rxe workarounds

### DIFF
--- a/working/Build_RxE_workarounds.sql
+++ b/working/Build_RxE_workarounds.sql
@@ -1,0 +1,248 @@
+drop table if exists workaround_cleanup
+;
+create unlogged table workaround_cleanup as
+--gather all Clinical Drug Comps which have duplicates within 0.05 dosage
+with dup_list as
+	(
+		select
+			c.concept_id,
+			c.concept_name,
+			s.numerator_value / 10 ^ floor (log (s.numerator_value)) as normal_value,
+			c2.concept_id as dup_concept_id,
+			c2.concept_name as dup_concept_name,
+			s2.numerator_value / 10 ^ floor (log (s2.numerator_value)) as dup_normal_value
+		from concept c
+		join concept c2 on
+			c.concept_class_id = 'Clinical Drug Comp' and
+			c2.concept_class_id = 'Clinical Drug Comp' and
+			c.standard_concept = 'S' and
+			c2.standard_concept = 'S' and
+			c.concept_id != c2.concept_id
+		join drug_strength s on
+			s.drug_concept_id = c.concept_id
+		join drug_strength s2 on
+			s2.drug_concept_id = c2.concept_id and
+			s2.denominator_unit_concept_id = s.denominator_unit_concept_id and
+			s2.numerator_unit_concept_id = s.numerator_unit_concept_id and
+			s2.ingredient_concept_id = s.ingredient_concept_id and
+			s2.numerator_value > s.numerator_value and
+			s2.numerator_value * 0.95 < s.numerator_value
+	),
+--unify comp groups by lowest member
+dup_groups as
+	(
+		select
+			d1.concept_id as group_id,
+			d1.dup_concept_id as dup_concept_id,
+			d1.dup_normal_value as dup_normal_value
+		from dup_list d1
+		--don't create groups from not the lowest
+		left join dup_list d3 on
+			d1.concept_id = d3.dup_concept_id
+		where d3.dup_concept_id is null
+
+			union
+
+		--get subsequent duplicates over medium level members
+		select distinct
+			d1.concept_id as group_id,
+			d2.dup_concept_id,
+			d2.dup_normal_value
+		from dup_list d1
+		join dup_list d2 on
+			d2.concept_id = d2.dup_concept_id
+		--don't create groups from not the lowest
+		left join dup_list d3 on
+			d1.concept_id = d3.dup_concept_id
+		where d3.dup_concept_id is null
+
+			union
+		--add self
+		select distinct
+			d1.concept_id as group_id,
+			d1.concept_id,
+			d1.normal_value
+		from dup_list d1
+		--don't create groups from not the lowest
+		left join dup_list d3 on
+			d1.concept_id = d3.dup_concept_id
+		where d3.dup_concept_id is null
+	),
+--Find the best (simplest) target in group and exclude the rest
+dup_ranked as
+	(
+		select
+			group_id,
+			dup_concept_id,
+			dup_concept_id =
+				(
+					first_value (dup_concept_id) over
+						(
+							partition by group_id
+							order by
+							--Measures how "simple" a number looks
+								dup_normal_value % 0.05 asc,
+								dup_normal_value % 0.1 asc,
+								dup_normal_value % 0.25 asc,
+								dup_normal_value % 0.5 asc
+						)
+				) as best_in_group
+		from dup_groups
+	),
+--This excludes concepts that stem from duplicate components
+blacklist as
+	(
+		select
+			drug_concept_id as component_concept_id,
+			ingredient_concept_id
+		from drug_strength a
+		join dup_ranked on
+			best_in_group = false and
+			drug_concept_id = dup_concept_id
+	),
+exclusion as
+	(
+		select a.descendant_concept_id
+		from concept_ancestor a
+		join blacklist b on
+			component_concept_id = ancestor_concept_id
+	--Sometimes drugs may have more than one component with same ingredient as ancestor (NaCl 8.8 & NaCl 9); exclude those.
+		where not exists
+			(
+				select 1
+				from concept_ancestor x
+				join drug_strength d on
+					x.descendant_concept_id = a.descendant_concept_id and
+					d.ingredient_concept_id = b.ingredient_concept_id and
+					d.drug_concept_id = x.ancestor_concept_id and
+					x.ancestor_concept_id != b.component_concept_id
+				join concept c on
+					d.drug_concept_id = c.concept_id and
+					c.concept_class_id = 'Clinical Drug Comp'
+			)
+	)
+select c.concept_id as bad_concept_id, 'Contributing Drug Component is a dublicate' as exclusion_criterion
+from concept c
+where exists	
+	(select 1 from exclusion where c.concept_id = descendant_concept_id)
+
+	union all
+
+--This will remove concepts that have valid relation to inactive attributes; Build_RxE would otherwise treat them as duplicate concepts of another class
+select concept_id as bad_concept_id, 'Valid relation to invalid attribute' as exclusion_criterion
+from concept c
+where
+    c.invalid_reason is null and
+    c.vocabulary_id in ('RxNorm', 'RxNorm Extension') and
+    c.domain_id = 'Drug' and
+    c.concept_class_id != 'Ingredient' and
+    c.concept_id in
+    (
+    	select concept_id_2
+        from concept_relationship r
+        join concept c on
+            r.relationship_id = 'Brand name of' and
+            c.concept_id = r.concept_id_1 and
+            c.concept_class_id = 'Brand Name' and
+            c.vocabulary_id in ('RxNorm', 'RxNorm Extension') and
+            c.invalid_reason is not null and
+            r.invalid_reason is null
+            --some may still have another valid attribute
+            and not exists
+            	(
+            		select 1
+            		from concept_relationship xr
+            		join concept xc on
+            			r.concept_id_2 = xr.concept_id_2 and
+            			r.concept_id_1 != xr.concept_id_1 and
+            			xr.relationship_id = 'Brand name of' and
+            			xc.invalid_reason is null and
+            			xr.invalid_reason is null and
+            			xr.concept_id_1 = xc.concept_id
+            	)
+
+			union all
+
+        select concept_id_2
+        from concept_relationship r
+        join concept c on
+            r.relationship_id = 'RxNorm dose form of' and
+            c.concept_id = r.concept_id_1 and
+            c.concept_class_id = 'Dose Form' and
+            c.vocabulary_id in ('RxNorm', 'RxNorm Extension') and
+            c.invalid_reason is not null and
+            r.invalid_reason is null
+            --some may still have another valid attribute
+          	and not exists
+
+            	(
+            		select 1
+            		from concept_relationship xr
+            		join concept xc on
+            			r.concept_id_2 = xr.concept_id_2 and
+            			r.concept_id_1 != xr.concept_id_1 and
+            			xr.relationship_id = 'RxNorm dose form of' and
+            			xc.invalid_reason is null and
+            			xr.invalid_reason is null and
+            			xr.concept_id_1 = xc.concept_id
+            	)
+
+                         union all
+               
+        select concept_id_2
+        from concept_relationship r
+        join concept c on
+            r.relationship_id = 'Supplier of' and
+            c.concept_id = r.concept_id_1 and
+            c.concept_class_id = 'Supplier' and
+            c.vocabulary_id in ('RxNorm', 'RxNorm Extension') and
+            c.invalid_reason is not null and
+            r.invalid_reason is null
+            --some may still have another valid attribute
+            and not exists
+            	(
+            		select 1
+            		from concept_relationship xr
+            		join concept xc on
+            			r.concept_id_2 = xr.concept_id_2 and
+            			r.concept_id_1 != xr.concept_id_1 and
+            			xr.relationship_id = 'Supplier of' and
+            			xc.invalid_reason is null and
+            			xr.invalid_reason is null and
+            			xr.concept_id_1 = xc.concept_id
+            	)
+    )
+;
+update concept c
+set
+	invalid_reason = 'D',
+	valid_end_date = current_date - 1
+where
+	exists
+		(
+			select 1
+			from workaround_cleanup
+			where
+				c.concept_id = bad_concept_id
+		)
+;
+delete from concept_relationship r
+where
+	exists
+		(
+			select 1
+			from workaround_cleanup
+			where
+				bad_concept_id in (r.concept_id_1, r.concept_id_2)
+		)
+;
+delete from drug_strength
+where
+	exists
+		(
+			select 1
+			from workaround_cleanup
+			where
+				drug_concept_id = bad_concept_id
+		)
+;

--- a/working/Build_RxE_workarounds.sql
+++ b/working/Build_RxE_workarounds.sql
@@ -216,6 +216,7 @@ where
 update concept c
 set
 	invalid_reason = 'D',
+	standard_concept = NULL,
 	valid_end_date = current_date - 1
 where
 	exists


### PR DESCRIPTION
Following script creates drug input tables that pass all QA, but break BuildRxE due to persistent problems in basic tables. Using workaround script allows to BuildRxE to complete without any issues.

`DO $_$
BEGIN
	PERFORM VOCABULARY_PACK.SetLatestUpdate(
	pVocabularyName			=> 'NDC',
	pVocabularyDate			=> (SELECT vocabulary_date FROM sources.ggr_ir LIMIT 1),
	pVocabularyVersion		=> (SELECT vocabulary_version FROM sources.ggr_ir LIMIT 1),
	pVocabularyDevSchema	=> 'DEV_EDUARD'
);
	PERFORM VOCABULARY_PACK.SetLatestUpdate(
	pVocabularyName			=> 'RxNorm Extension',
	pVocabularyDate			=> CURRENT_DATE,
	pVocabularyVersion		=> 'RxNorm Extension '||CURRENT_DATE,
	pVocabularyDevSchema	=> 'DEV_EDUARD',
	pAppendVocabulary		=> TRUE
);
END $_$;

drop table drug_concept_stage cascade
;
create table drug_concept_stage as
select * from dev_rxe.drug_concept_stage where false
;
insert into drug_concept_stage (domain_id,concept_name,vocabulary_id,concept_class_id,concept_code,standard_concept,valid_start_date,valid_end_date,invalid_reason)
values
	('Drug', 'Acetominophen and NaCl; Acetominophen has perfect div', 'NDC', 'Drug Product', 'code1', null, to_date ('1970-01-01','yyyy-mm-dd'),  to_date ('2099-12-31','yyyy-mm-dd'), null),
 --	('Drug', 'Acetominophen and NaCl; Acetominophen has bad div', 'NDC', 'Drug Product', 'code2', null, to_date ('1970-01-01','yyyy-mm-dd'),  to_date ('2099-12-31','yyyy-mm-dd'), null),
	('Drug', 'Acetominophen', 'NDC', 'Ingredient', 'ing1', 'S', to_date ('1970-01-01','yyyy-mm-dd'),  to_date ('2099-12-31','yyyy-mm-dd'), null),
	('Drug', 'Sodium Chloride', 'NDC', 'Ingredient', 'ing2', 'S', to_date ('1970-01-01','yyyy-mm-dd'),  to_date ('2099-12-31','yyyy-mm-dd'), null),
	('Drug', 'Solution', 'NDC', 'Dose Form', 'df1', null, to_date ('1970-01-01','yyyy-mm-dd'),  to_date ('2099-12-31','yyyy-mm-dd'), null)
;
truncate internal_relationship_stage
;
insert into internal_relationship_stage
select
	d1.concept_code,
	d2.concept_code
from drug_concept_stage d1
join drug_concept_stage d2 on
	d1.concept_code ~ '^code\d$' and
	d2.concept_code !~ '^code\d$'
;
truncate ds_stage, pc_stage
;
insert into ds_stage (drug_concept_code,ingredient_concept_code,numerator_value,numerator_unit,denominator_value,denominator_unit)
values
	('code1','ing1',500,'mg',1,'ml'),
-- 	('code2','ing1',500*0.95+1,'mg',1,'ml'),
	('code1','ing2',9,'mg',1,'ml')
-- 	,('code2','ing2',9,'mg',1,'ml')
;
truncate relationship_to_concept
;
insert into relationship_to_concept (concept_code_1,concept_id_2,precedence,conversion_factor)
values
	('mg',8576,1,1),
	('ml',8587,1,1),
	('ing1',1125315,1,1),
	('ing2',967823,1,1),
	('df1',19082170,1,1)
;
update relationship_to_concept
set vocabulary_id_1 = 'NDC'
;
select * from ds_stage

`